### PR TITLE
Remove sockets from NIOHandler's KeyedSemaphore in all cases

### DIFF
--- a/src/gov/nist/javax/sip/stack/NIOHandler.java
+++ b/src/gov/nist/javax/sip/stack/NIOHandler.java
@@ -134,7 +134,7 @@ public class NIOHandler {
     				logger.logDebug("Removing cached socketChannel without key"
     						+ this + " socketChannel = " + channel + " key = " + key);
     			}
-    			socketTable.remove(key);
+    			removeSocket(key);
     		}
     	}
     }


### PR DESCRIPTION
When removing a socket via NIOHandler::removeSocket(SocketChannel) there
is no call to remove the channel's key from the KeyedSemaphore. Fixed
this by making this method call NIOHandler::removeSocket(String) for
each key so that both cases clean up the same way.