### PR TITLE
Close race condition in removeSocket

### DIFF
--- a/src/gov/nist/javax/sip/stack/IOHandler.java
+++ b/src/gov/nist/javax/sip/stack/IOHandler.java
@@ -106,9 +106,9 @@ public class IOHandler {
 
     protected void removeSocket(String key) {
         socketTable.remove(key);
-        if ( socketCreationMap.get(key) != null ) {
-        	socketCreationMap.get(key).release();
-        	socketCreationMap.remove(key);
+        Semaphore s = socketCreationMap.remove(key);
+        if ( s != null ) {
+        	s.release();
         }
         if (logger.isLoggingEnabled(StackLogger.TRACE_DEBUG)) {
             logger.logDebug("removed Socket and Semaphore for key " + key);


### PR DESCRIPTION
While doing some testing, I (rarely) saw a NullPointerException on line 110 of IOHandler.java. From a quick code read, I think I can see a race condition here: socketCreationMap.get(key) could return non-null for Thread 1 on line 109, Thread 2 could then reach line 111 and call socketCreationMap.remove(key), and it could return null on 110 for Thread 1.

This should fix that issue. 