### PR TITLE
Null pointer fix at DefaultRouter

### DIFF
--- a/src/gov/nist/javax/sip/message/SIPMessage.java
+++ b/src/gov/nist/javax/sip/message/SIPMessage.java
@@ -210,6 +210,10 @@ public abstract class SIPMessage extends MessageObject implements javax.sip.mess
       */
      private int localPort;
 
+     private InetAddress peerPacketSourceAddress;
+     
+     private int peerPacketSourcePort;
+
     /**
      * Return true if the header belongs only in a Request.
      *
@@ -2053,4 +2057,20 @@ public abstract class SIPMessage extends MessageObject implements javax.sip.mess
      public int getLocalPort() {
          return localPort;
      }
+
+    public void setPeerPacketSourceAddress(InetAddress peerPacketSourceAddress) {
+        this.peerPacketSourceAddress = peerPacketSourceAddress;
+    }
+    
+    public InetAddress getPeerPacketSourceAddress(){
+        return this.peerPacketSourceAddress;
+    }
+
+    public void setPeerPacketSourcePort(int peerPacketSourcePort) {
+        this.peerPacketSourcePort = peerPacketSourcePort;
+    }
+    
+    public int getPeerPacketSourcePort(){
+        return this.peerPacketSourcePort;
+    }
 }


### PR DESCRIPTION
In case of b2b UA and/or pure proxy behaviour, the routes list may not be null but the only remaining entry might be removed via proxy in order to route the message to its final destination.
